### PR TITLE
Simplify arithmetic expression in tcr_horizontal_line

### DIFF
--- a/tcr/tcr_shell/tcr_shell.sh
+++ b/tcr/tcr_shell/tcr_shell.sh
@@ -55,7 +55,7 @@ tcr_info() {
 
 tcr_horizontal_line() {
   term_columns=$(tput cols)
-  repeated=$(("${term_columns}" - 7))
+  repeated=$((term_columns - 7))
   line=$(head -c "${repeated}" </dev/zero | tr '\0' '-')
   tcr_info "$line"
 }


### PR DESCRIPTION
To fix tcr on macos
- remove the double quotes
- simplify the arithmetic expression according to https://github.com/koalaman/shellcheck/wiki/Sc2004